### PR TITLE
extremely minor nitpicks from `cargo clippy`

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src = [
         "Native-Miuchiz-Handheld-USB-Utilities/libmiuchiz-usb/src/commands.c",
         "Native-Miuchiz-Handheld-USB-Utilities/libmiuchiz-usb/src/libmiuchiz-usb.c",
-        "Native-Miuchiz-Handheld-USB-Utilities/libmiuchiz-usb/src/timer.c"
+        "Native-Miuchiz-Handheld-USB-Utilities/libmiuchiz-usb/src/timer.c",
     ];
     let mut builder = cc::Build::new();
     let build = builder
@@ -11,4 +11,4 @@ fn main() {
         .flag("-Wno-sign-compare")
         .flag("-Wno-extra");
     build.compile("libmiuchiz-usb");
- }
+}

--- a/src/libmiuchiz_usb/mod.rs
+++ b/src/libmiuchiz_usb/mod.rs
@@ -52,7 +52,7 @@ impl HandheldSet {
     }
 
     pub fn destroy_all(&mut self) {
-        if self.raw_handhelds != std::ptr::null_mut::<*mut Handheld>() {
+        if !self.raw_handhelds.is_null() {
             unsafe {
                 miuchiz_handheld_destroy_all(self.raw_handhelds);
             }

--- a/src/libmiuchiz_usb/mod.rs
+++ b/src/libmiuchiz_usb/mod.rs
@@ -2,35 +2,34 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-use std::{path::Path, ffi::{CStr}};
+use std::{ffi::CStr, path::Path};
 
 include!("./bindings.rs");
 
-
 pub struct HandheldSet {
     raw_handhelds: *mut *mut Handheld,
-    pub num_handhelds: u32
+    pub num_handhelds: u32,
 }
 
 impl HandheldSet {
     pub fn new() -> HandheldSet {
         let mut handheld_set: HandheldSet;
-    
+
         unsafe {
             handheld_set = HandheldSet {
                 raw_handhelds: std::ptr::null_mut() as *mut *mut Handheld,
-                num_handhelds: 0
+                num_handhelds: 0,
             };
-    
+
             let result = miuchiz_handheld_create_all(&mut handheld_set.raw_handhelds);
             if result >= 0 {
                 handheld_set.num_handhelds = result as u32;
             }
         }
-    
+
         handheld_set
     }
-    
+
     pub fn get_handheld_paths(&self) -> Vec<&Path> {
         let mut result: Vec<&Path> = Vec::new();
         result.reserve(self.num_handhelds as usize);
@@ -43,7 +42,7 @@ impl HandheldSet {
                 let path_i8 = (*handheld).device;
                 slice = CStr::from_ptr(path_i8);
             }
-            
+
             if let Ok(str) = std::str::from_utf8(slice.to_bytes()) {
                 let path = Path::new(str);
                 result.push(path);
@@ -82,27 +81,25 @@ impl HandheldSet {
                 }
             }
         }
-        
+
         handheld
     }
 
-    pub fn write_page(&self, path: &Path, page: u32, buf: &Vec<u8>) -> Result<(), String>
-    {
+    pub fn write_page(&self, path: &Path, page: u32, buf: &Vec<u8>) -> Result<(), String> {
         if let Some(raw_handheld) = self.get_handheld_by_path(path) {
             unsafe {
                 let result = miuchiz_handheld_write_page(
-                    raw_handheld, 
-                    page as i32, 
-                    buf.as_ptr() as *const ::std::os::raw::c_void, 
-                    buf.len() as size_t
+                    raw_handheld,
+                    page as i32,
+                    buf.as_ptr() as *const ::std::os::raw::c_void,
+                    buf.len() as size_t,
                 );
                 if result < 0 {
-                    return Err("Error writing page".to_string())
+                    return Err("Error writing page".to_string());
                 }
             }
             Ok(())
-        }
-        else {
+        } else {
             Err("Could not find handheld".to_string())
         }
     }
@@ -112,18 +109,17 @@ impl HandheldSet {
         if let Some(raw_handheld) = self.get_handheld_by_path(path) {
             unsafe {
                 let result = miuchiz_handheld_read_page(
-                    raw_handheld, 
+                    raw_handheld,
                     page as i32,
                     result.as_ptr() as *mut ::std::os::raw::c_void,
-                    result.len() as size_t
+                    result.len() as size_t,
                 );
                 if result < 0 {
-                    return Err("Error reading page".to_string())
+                    return Err("Error reading page".to_string());
                 }
             }
             Ok(result)
-        }
-        else {
+        } else {
             Err("Could not find handheld".to_string())
         }
     }
@@ -138,5 +134,3 @@ impl Drop for HandheldSet {
         self.destroy_all();
     }
 }
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ impl MiuchizApp {
             progress_tx.send((page as u32, PAGE_NUM as u32)).ok();
         }
 
-        if let Err(_) = fs::write(file, data) {
+        if fs::write(file, data).is_err() {
             return Err("Unable to write to file.".to_string());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,7 @@ impl MiuchizApp {
 
             // rare
             if elapsed > MAX_PAGE_TIME {
-                let new_page = page.checked_sub(1).or(Some(0)).unwrap();
+                let new_page = page.saturating_sub(1);
                 text_tx
                     .send(format!(
                         "Page {page} took a long time to write. Restarting from {new_page}."

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![windows_subsystem = "windows"]
 use std::{
     fs,
+    path::Path,
     path::PathBuf,
     sync::mpsc::{channel, Receiver, Sender},
     thread::{self, sleep},
@@ -149,8 +150,8 @@ impl MiuchizApp {
     }
 
     fn flash(
-        device: &PathBuf,
-        file: &PathBuf,
+        device: &Path,
+        file: &Path,
         progress_tx: &Sender<(u32, u32)>,
         text_tx: &Sender<String>,
     ) -> Result<(), String> {
@@ -201,11 +202,7 @@ impl MiuchizApp {
         Ok(())
     }
 
-    fn dump(
-        device: &PathBuf,
-        file: &PathBuf,
-        progress_tx: &Sender<(u32, u32)>,
-    ) -> Result<(), String> {
+    fn dump(device: &Path, file: &Path, progress_tx: &Sender<(u32, u32)>) -> Result<(), String> {
         let mut data: Vec<u8> = Vec::new();
 
         let set = libmiuchiz_usb::HandheldSet::new();
@@ -351,10 +348,7 @@ impl MiuchizApp {
                 if ui.button("Dump flash").clicked() {
                     if let Some(device) = self.selected_handheld.clone() {
                         if let Some(file) = FileDialog::new().save_file() {
-                            self.try_set_state(MiuchizProcess::Reading {
-                                file,
-                                device: device.to_path_buf(),
-                            });
+                            self.try_set_state(MiuchizProcess::Reading { file, device });
                         }
                     }
                 }
@@ -389,8 +383,8 @@ impl MiuchizApp {
                         self.selected_handheld.clone(),
                     ) {
                         self.try_set_state(MiuchizProcess::Flashing {
-                            file: flash_file.to_path_buf(),
-                            device: device.to_path_buf(),
+                            file: flash_file,
+                            device,
                         });
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,11 @@
 #![windows_subsystem = "windows"]
-use std::{thread::{self, sleep}, sync::mpsc::{channel, Receiver, Sender}, path::PathBuf, time::Duration, fs};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::mpsc::{channel, Receiver, Sender},
+    thread::{self, sleep},
+    time::Duration,
+};
 
 use eframe::{egui, emath::Vec2};
 use rfd::FileDialog;
@@ -23,13 +29,13 @@ struct MiuchizApp {
     text_rx: Receiver<String>,
     text: String,
     processing_state: MiuchizProcess,
-    progress_amount: Option<(u32, u32)>
+    progress_amount: Option<(u32, u32)>,
 }
 #[derive(Clone, Debug)]
 enum MiuchizProcess {
     WatchingForHandhelds,
-    Flashing {file: PathBuf, device: PathBuf},
-    Reading {file: PathBuf, device: PathBuf}
+    Flashing { file: PathBuf, device: PathBuf },
+    Reading { file: PathBuf, device: PathBuf },
 }
 
 impl Default for MiuchizProcess {
@@ -41,7 +47,7 @@ impl Default for MiuchizProcess {
 #[derive(PartialEq)]
 enum MiuchizAppTab {
     DumpView,
-    FlashView
+    FlashView,
 }
 
 impl Default for MiuchizAppTab {
@@ -62,7 +68,7 @@ impl MiuchizApp {
             Self::process(list_tx, process_rx, process_tx2, progress_tx, text_tx);
         });
 
-        Self { 
+        Self {
             app_tab: MiuchizAppTab::default(),
             list_rx,
             handheld_list: Vec::new(),
@@ -74,27 +80,27 @@ impl MiuchizApp {
             text_rx,
             text: "OK".to_string(),
             processing_state: MiuchizProcess::default(),
-            progress_amount: None
+            progress_amount: None,
         }
     }
 
     fn process(
-        list_tx: Sender<Vec<PathBuf>>, 
-        process_rx: Receiver<MiuchizProcess>, 
+        list_tx: Sender<Vec<PathBuf>>,
+        process_rx: Receiver<MiuchizProcess>,
         process_tx: Sender<MiuchizProcess>,
         progress_tx: Sender<(u32, u32)>,
-        text_tx: Sender<String>
-        ) {
+        text_tx: Sender<String>,
+    ) {
         let mut state = MiuchizProcess::default();
 
         loop {
             match process_rx.try_recv() {
                 Ok(new_state) => state = new_state,
-                Err(_) => {},
+                Err(_) => {}
             }
 
             match process_tx.send(state.clone()) {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(_) => break,
             }
 
@@ -106,63 +112,68 @@ impl MiuchizApp {
                         let set = libmiuchiz_usb::HandheldSet::new();
                         let paths = set.get_handheld_paths();
                         new_paths.reserve(paths.len());
-        
+
                         for p in paths {
                             new_paths.push(p.to_path_buf());
                         }
                     }
-        
+
                     match list_tx.send(new_paths) {
-                        Ok(_) => {},
+                        Ok(_) => {}
                         Err(_) => break,
                     }
-        
+
                     sleep(Duration::from_millis(250));
-                },
-                MiuchizProcess::Flashing { file, device } =>  {
+                }
+                MiuchizProcess::Flashing { file, device } => {
                     text_tx.send("OK".to_string()).ok();
                     if let Err(message) = Self::flash(device, file, &progress_tx, &text_tx) {
                         text_tx.send(message).ok();
+                    } else {
+                        text_tx
+                            .send("Finished writing to handheld.".to_string())
+                            .ok();
                     }
-                    else {
-                        text_tx.send("Finished writing to handheld.".to_string()).ok();
-                    }
-                },
-                MiuchizProcess::Reading { file, device } =>  {
+                }
+                MiuchizProcess::Reading { file, device } => {
                     text_tx.send("OK".to_string()).ok();
                     if let Err(message) = Self::dump(device, file, &progress_tx) {
                         text_tx.send(message).ok();
-                    }
-                    else {
+                    } else {
                         text_tx.send("Finished reading handheld.".to_string()).ok();
                     }
-                },
+                }
             }
 
             state = MiuchizProcess::WatchingForHandhelds;
         }
     }
 
-    fn flash(device: &PathBuf, file: &PathBuf, progress_tx: &Sender<(u32, u32)>, text_tx: &Sender<String>) -> Result<(), String> {
+    fn flash(
+        device: &PathBuf,
+        file: &PathBuf,
+        progress_tx: &Sender<(u32, u32)>,
+        text_tx: &Sender<String>,
+    ) -> Result<(), String> {
         const MAX_PAGE_TIME: Duration = Duration::from_secs(3);
         let data = if let Ok(data) = fs::read(file) {
             data
-        }
-        else {
+        } else {
             return Err("Unable to read file.".to_string());
         };
 
         if data.len() != FLASH_FILE_SIZE {
-            return Err(format!("Flash file is not the correct size ({FLASH_FILE_SIZE})."));
+            return Err(format!(
+                "Flash file is not the correct size ({FLASH_FILE_SIZE})."
+            ));
         }
-
 
         let set = libmiuchiz_usb::HandheldSet::new();
 
         let mut page: usize = 0;
         while page < PAGE_NUM {
             let page_start = page * PAGE_SIZE;
-            let page_end = (page+1) * PAGE_SIZE;
+            let page_end = (page + 1) * PAGE_SIZE;
             let buf = &data.as_slice()[page_start..page_end].to_vec();
 
             let now = std::time::Instant::now();
@@ -172,24 +183,30 @@ impl MiuchizApp {
             // rare
             if elapsed > MAX_PAGE_TIME {
                 let new_page = page.checked_sub(1).or(Some(0)).unwrap();
-                text_tx.send(format!("Page {page} took a long time to write. Restarting from {new_page}.")).ok();
+                text_tx
+                    .send(format!(
+                        "Page {page} took a long time to write. Restarting from {new_page}."
+                    ))
+                    .ok();
                 page = new_page;
                 thread::sleep(Duration::from_secs(1));
-            }
-            else {
+            } else {
                 page += 1;
             }
-            
+
             progress_tx.send((page as u32, PAGE_NUM as u32)).ok();
         }
-        
+
         set.eject(device);
 
         Ok(())
-
     }
 
-    fn dump(device: &PathBuf, file: &PathBuf, progress_tx: &Sender<(u32, u32)>) -> Result<(), String> {
+    fn dump(
+        device: &PathBuf,
+        file: &PathBuf,
+        progress_tx: &Sender<(u32, u32)>,
+    ) -> Result<(), String> {
         let mut data: Vec<u8> = Vec::new();
 
         let set = libmiuchiz_usb::HandheldSet::new();
@@ -205,16 +222,15 @@ impl MiuchizApp {
         }
 
         Ok(())
-
     }
 
     fn update_messages(&mut self) {
         // update handheld list
         match self.list_rx.try_recv() {
             Ok(message) => self.handheld_list = message,
-            Err(_) => {},
+            Err(_) => {}
         }
-        
+
         // Make sure selected handheld is still present
         if let Some(selected_handheld) = &self.selected_handheld {
             let mut selected_handheld_still_valid: bool = false;
@@ -232,23 +248,22 @@ impl MiuchizApp {
 
         match self.process_rx.try_recv() {
             Ok(state) => self.processing_state = state,
-            Err(_) => {},
+            Err(_) => {}
         }
 
         match self.progress_rx.try_recv() {
             Ok(progress) => {
                 self.progress_amount = Some(progress);
-            },
+            }
             Err(_) => {}
         }
 
         match self.text_rx.try_recv() {
             Ok(text) => {
                 self.text = text;
-            },
+            }
             Err(_) => {}
         }
-
     }
 
     fn try_set_state(&mut self, process: MiuchizProcess) {
@@ -256,8 +271,8 @@ impl MiuchizApp {
             MiuchizProcess::WatchingForHandhelds => {
                 self.progress_amount = None;
                 self.process_tx.send(process).ok();
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
 
@@ -267,19 +282,10 @@ impl MiuchizApp {
             .show_inside(ui, |ui| {
                 ui.horizontal(|ui| {
                     ui.heading("Tasks");
-                    ui.selectable_value(
-                        &mut self.app_tab,
-                        MiuchizAppTab::DumpView,
-                        "Dump" 
-                    );
-                    ui.selectable_value(
-                        &mut self.app_tab,
-                        MiuchizAppTab::FlashView,
-                        "Flash" 
-                    );
+                    ui.selectable_value(&mut self.app_tab, MiuchizAppTab::DumpView, "Dump");
+                    ui.selectable_value(&mut self.app_tab, MiuchizAppTab::FlashView, "Flash");
                 });
-            }
-        );
+            });
     }
 
     fn handhelds_panel(&mut self, ui: &mut egui::Ui) {
@@ -289,16 +295,17 @@ impl MiuchizApp {
             .show_inside(ui, |ui| {
                 ui.heading("Connected handhelds");
                 ui.separator();
-                egui::ScrollArea::vertical().auto_shrink([false, false]).show(ui, |ui| {
-                    for p in &self.handheld_list {
-                        let btn_response = ui.button(p.display().to_string());
-                        if btn_response.clicked() {
-                            self.selected_handheld = Some(p.to_path_buf());
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        for p in &self.handheld_list {
+                            let btn_response = ui.button(p.display().to_string());
+                            if btn_response.clicked() {
+                                self.selected_handheld = Some(p.to_path_buf());
+                            }
                         }
-                    }
-                });
-            }
-        );
+                    });
+            });
     }
 
     fn info_panel(&mut self, ui: &mut egui::Ui) {
@@ -308,15 +315,13 @@ impl MiuchizApp {
                 ui.horizontal_centered(|ui| {
                     ui.label(format!("Status: {}", &self.text));
                 });
-            }
-        );
+            });
     }
 
     fn progress(&mut self, ui: &mut egui::Ui) {
         let (current_progress, max_progress) = if let Some(progress) = self.progress_amount {
             (progress.0, progress.1)
-        }
-        else {
+        } else {
             (0, 0)
         };
 
@@ -341,12 +346,11 @@ impl MiuchizApp {
         ui.label(format!("Selected handheld: "));
         if let Some(selected_handheld) = &self.selected_handheld {
             ui.colored_label(FILE_COLOR, selected_handheld.display().to_string());
-        }
-        else {
+        } else {
             ui.colored_label(egui::Color32::RED, "None");
         }
     }
-    
+
     fn dump_view(&mut self, ui: &mut egui::Ui) {
         egui::CentralPanel::default().show_inside(ui, |ui| {
             ui.vertical_centered_justified(|ui| {
@@ -356,12 +360,10 @@ impl MiuchizApp {
                 if ui.button("Dump flash").clicked() {
                     if let Some(device) = self.selected_handheld.clone() {
                         if let Some(file) = FileDialog::new().save_file() {
-                            self.try_set_state(
-                                MiuchizProcess::Reading { 
-                                    file, 
-                                    device: device.to_path_buf() 
-                                }
-                            );
+                            self.try_set_state(MiuchizProcess::Reading {
+                                file,
+                                device: device.to_path_buf(),
+                            });
                         }
                     }
                 }
@@ -381,8 +383,7 @@ impl MiuchizApp {
                     ui.label(format!("Selected flash file: "));
                     if let Some(flash_file) = &self.selected_load_file {
                         ui.colored_label(FILE_COLOR, flash_file.display().to_string());
-                    }
-                    else {
+                    } else {
                         ui.colored_label(egui::Color32::RED, "None");
                     }
                 });
@@ -392,13 +393,14 @@ impl MiuchizApp {
                     }
                 }
                 if ui.button("Load flash").clicked() {
-                    if let (Some(flash_file), Some(device)) = (self.selected_load_file.clone(), self.selected_handheld.clone()) {
-                        self.try_set_state(
-                            MiuchizProcess::Flashing { 
-                                file: flash_file.to_path_buf(), 
-                                device: device.to_path_buf() 
-                            }
-                        );
+                    if let (Some(flash_file), Some(device)) = (
+                        self.selected_load_file.clone(),
+                        self.selected_handheld.clone(),
+                    ) {
+                        self.try_set_state(MiuchizProcess::Flashing {
+                            file: flash_file.to_path_buf(),
+                            device: device.to_path_buf(),
+                        });
                     }
                 }
                 ui.separator();
@@ -416,21 +418,19 @@ impl eframe::App for MiuchizApp {
             self.tabs(ui);
             self.handhelds_panel(ui);
             self.info_panel(ui);
-            
+
             match self.app_tab {
                 MiuchizAppTab::DumpView => self.dump_view(ui),
-                MiuchizAppTab::FlashView => self.flash_view(ui)
+                MiuchizAppTab::FlashView => self.flash_view(ui),
             }
         });
     }
-
-
 }
 
 fn main() {
-    let window_size = Some(Vec2 {x: 800.0, y: 400.0});
+    let window_size = Some(Vec2 { x: 800.0, y: 400.0 });
     eframe::run_native(
-        "Miuchiz USB Utility", 
+        "Miuchiz USB Utility",
         eframe::NativeOptions {
             drag_and_drop_support: true,
             //icon_data: todo!(),
@@ -440,7 +440,6 @@ fn main() {
             resizable: false,
             ..eframe::NativeOptions::default()
         },
-        Box::new(|_cc| {
-            Box::new(MiuchizApp::new())
-        }))
+        Box::new(|_cc| Box::new(MiuchizApp::new())),
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,7 +331,7 @@ impl MiuchizApp {
     }
 
     fn selected_handheld_label(&self, ui: &mut egui::Ui) {
-        ui.label(format!("Selected handheld: "));
+        ui.label("Selected handheld: ".to_string());
         if let Some(selected_handheld) = &self.selected_handheld {
             ui.colored_label(FILE_COLOR, selected_handheld.display().to_string());
         } else {
@@ -365,7 +365,7 @@ impl MiuchizApp {
                     self.selected_handheld_label(ui);
                 });
                 ui.horizontal(|ui| {
-                    ui.label(format!("Selected flash file: "));
+                    ui.label("Selected flash file: ".to_string());
                     if let Some(flash_file) = &self.selected_load_file {
                         ui.colored_label(FILE_COLOR, flash_file.display().to_string());
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,9 +94,8 @@ impl MiuchizApp {
         let mut state = MiuchizProcess::default();
 
         loop {
-            match process_rx.try_recv() {
-                Ok(new_state) => state = new_state,
-                Err(_) => {}
+            if let Ok(new_state) = process_rx.try_recv() {
+                state = new_state
             }
 
             match process_tx.send(state.clone()) {
@@ -226,9 +225,8 @@ impl MiuchizApp {
 
     fn update_messages(&mut self) {
         // update handheld list
-        match self.list_rx.try_recv() {
-            Ok(message) => self.handheld_list = message,
-            Err(_) => {}
+        if let Ok(message) = self.list_rx.try_recv() {
+            self.handheld_list = message
         }
 
         // Make sure selected handheld is still present
@@ -246,23 +244,16 @@ impl MiuchizApp {
             }
         }
 
-        match self.process_rx.try_recv() {
-            Ok(state) => self.processing_state = state,
-            Err(_) => {}
+        if let Ok(state) = self.process_rx.try_recv() {
+            self.processing_state = state
         }
 
-        match self.progress_rx.try_recv() {
-            Ok(progress) => {
-                self.progress_amount = Some(progress);
-            }
-            Err(_) => {}
+        if let Ok(progress) = self.progress_rx.try_recv() {
+            self.progress_amount = Some(progress);
         }
 
-        match self.text_rx.try_recv() {
-            Ok(text) => {
-                self.text = text;
-            }
-            Err(_) => {}
+        if let Ok(text) = self.text_rx.try_recv() {
+            self.text = text;
         }
     }
 


### PR DESCRIPTION
* Ran standard formatter `cargo fmt`.
* Ran standard linter `cargo clippy`, addressed warnings.